### PR TITLE
Version 21d

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,15 @@
+v_:B	vis.txt	/*v_:B*
+vis	vis.txt	/*vis*
+vis-S	vis.txt	/*vis-S*
+vis-contents	vis.txt	/*vis-contents*
+vis-copyright	vis.txt	/*vis-copyright*
+vis-history	vis.txt	/*vis-history*
+vis-manual	vis.txt	/*vis-manual*
+vis-required	vis.txt	/*vis-required*
+vis-search	vis.txt	/*vis-search*
+vis-sort	vis.txt	/*vis-sort*
+vis-srch	vis.txt	/*vis-srch*
+vis.txt	vis.txt	/*vis.txt*
+vis.vim	vis.txt	/*vis.vim*
+visman	vis.txt	/*visman*
+vismanual	vis.txt	/*vismanual*

--- a/doc/vis.txt
+++ b/doc/vis.txt
@@ -1,8 +1,8 @@
-*vis.txt*	The Visual Block Tool				Mar 29, 2013
+*vis.txt*	The Visual Block Tool				Jan 15, 2015
 
 Author:  Charles E. Campbell  <NdrchipO@ScampbellPfamily.AbizM>
 	  (remove NOSPAM from Campbell's email first)
-Copyright: (c) 2004-2013 by Charles E. Campbell	*vis-copyright*
+Copyright: (c) 2004-2015 by Charles E. Campbell	*vis-copyright*
            The VIM LICENSE applies to vis.vim and vis.txt
            (see |copyright|) except use "vis" instead of "Vim"
 	   No warranty, express or implied.  Use At-Your-Own-Risk.
@@ -38,10 +38,6 @@ Copyright: (c) 2004-2013 by Charles E. Campbell	*vis-copyright*
 	There must be a space before the '!' when invoking external shell
 	commands, eg. ':B !sort'. Otherwise an error is reported.
 
-	Doesn't work as one might expect with Vim's ve option.  That's
-	because ve=all ended up leaving unwanted blank columns, so the
-	solution chosen was to have the vis function turn ve off temporarily.
-
 	The script works by deleting the selected region into register "a.
 	The register "a itself is first saved and later restored.  The text is
 	then put at the end-of-file, modified by the user command, and then
@@ -71,7 +67,7 @@ Copyright: (c) 2004-2013 by Charles E. Campbell	*vis-copyright*
 	Visual block search provides two ways to get visual-selection
 	based searches.  Both these methods work well with :set hls
 	and searching may be repeated with the n or N commands.
-	
+
 	Using // and ?? after a visual selection (the // is only available
 	if you have g:vis_WantSlashSlash=1 in your <.vimrc> file):
 >
@@ -87,7 +83,7 @@ Copyright: (c) 2004-2013 by Charles E. Campbell	*vis-copyright*
 <
 	You may enter whatever pattern you want after the \&, and the
 	pattern search will be restricted to the requested region.
-	
+
 	The "S" command in visual mode:
 >
 		ex. select region via V, v, or ctrl-v
@@ -96,7 +92,7 @@ Copyright: (c) 2004-2013 by Charles E. Campbell	*vis-copyright*
 	    The ":S pattern" will appear as ":'<,'>S pattern".  This
 	    command will move the cursor to the next instance of the
 	    pattern, restricted to the visually selected block.
-	
+
 	An "R" command was contemplated, but I currently see no way to
 	get it to continue to search backwards with n and N commands.
 
@@ -167,6 +163,17 @@ Copyright: (c) 2004-2013 by Charles E. Campbell	*vis-copyright*
 ==============================================================================
 6. History						*vis-history* {{{1
 
+    v21 : Apr 01, 2013	- visual block and ragged right detection; there was
+			  a conflict between using ve= and ve=all
+			  (internally); one was good for ragged right and
+			  the other for smooth right visual block selections.
+			  I found a way to detect ragged right vs smooth right
+			  and so vis.vim now works properly in both
+			  situations.
+	  Apr 02, 2013	- The detection method above hung when on line 1.
+			  Fixed.
+	  Jan 15, 2015	- Small adjustment to prevent a leading space from
+	  		  being inserted.
     v20 : May 20, 2009	- cecutil bugfix
 	  May 19, 2010	- split into plugin/ and autoload/ for faster
 			  loading and on-demand loading.

--- a/plugin/cecutil.vim
+++ b/plugin/cecutil.vim
@@ -2,8 +2,8 @@
 "               save/restore mark position
 "               save/restore selected user maps
 "  Author:	Charles E. Campbell
-"  Version:	18h	ASTRO-ONLY
-"  Date:	Oct 16, 2012
+"  Version:	18i	ASTRO-ONLY
+"  Date:	Oct 21, 2013
 "
 "  Saving Restoring Destroying Marks: {{{1
 "       call SaveMark(markname)       let savemark= SaveMark(markname)
@@ -34,7 +34,7 @@
 if &cp || exists("g:loaded_cecutil")
  finish
 endif
-let g:loaded_cecutil = "v18h"
+let g:loaded_cecutil = "v18i"
 let s:keepcpo        = &cpo
 set cpo&vim
 "DechoRemOn

--- a/plugin/visPlugin.vim
+++ b/plugin/visPlugin.vim
@@ -44,8 +44,8 @@ set cpo&vim
 "  -range       : VisBlockCmd operates on the range itself
 "  -com=command : Ex command and arguments
 "  -nargs=+     : arguments may be supplied, up to any quantity
-com! -range -nargs=+ -com=command    B  silent <line1>,<line2>call vis#VisBlockCmd(<q-args>)
-com! -range -nargs=* -com=expression S  silent <line1>,<line2>call vis#VisBlockSearch(<q-args>)
+com! -range -nargs=+ -com=command    B  sil <line1>,<line2>call vis#VisBlockCmd(<q-args>)
+com! -range -nargs=* -com=expression S  sil <line1>,<line2>call vis#VisBlockSearch(<q-args>)
 
 " Suggested by Hari --
 if exists("g:vis_WantSlashSlash") && g:vis_WantSlashSlash


### PR DESCRIPTION
visual block and ragged right detection; there was a conflict between using ve=
  and ve=all (internally); one was good for ragged right and the other for
  smooth right visual block selections. I found a way to detect ragged right
  vs smooth right and so vis.vim now works properly in both situations.
The detection method above hung when on line 1. Fixed.
Small adjustment to prevent a leading space from being inserted.
